### PR TITLE
Reuse database connection when using repository outside controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ temp/
 *.log
 dist
 .nyc_output
+coverage

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start:dev": "npx task dev",
     "db:migration:new": "yarn run typeorm-ts migration:create -n ",
-    "db:migration:generate": "yarn run typeorm-ts migration:create -n ",
+    "db:migration:generate": "yarn run typeorm-ts migration:generate -n ",
     "db:entity:new": "yarn run typeorm-ts entity:create -n ",
     "db:subscriber:new": "yarn run typeorm-ts subscriber:create -n ",
     "db:migrate": "npx task npm typeorm-ts migration:run",

--- a/src/App.ts
+++ b/src/App.ts
@@ -36,6 +36,7 @@ export class App {
       .addHook("onClose", async function (instance) {
         await instance.db.close();
       });
+    await this.instance.db.runMigrations({transaction: "all"});
     await this.instance.ready();
     this.instance.blipp();
     return new Promise((resolve, reject) => {

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -15,7 +15,6 @@ export async function getDatabaseConnection(): Promise<Connection> {
       logger: new TypeOrmLogger()
     });
     conn = await openConnection(conn);
-    await conn.runMigrations({transaction: "all"});
   }
   return conn;
 }


### PR DESCRIPTION
- Reuse database connection and add getRepository for use outside controller
- Add coverage to .gitignore
- Fix migration generation command